### PR TITLE
Fix get_db_prep_save on JSONField for django 1.2

### DIFF
--- a/django_common/db_fields.py
+++ b/django_common/db_fields.py
@@ -47,7 +47,7 @@ class JSONField(models.TextField):
         if isinstance(value, dict):
             value = json.dumps(value, cls=DjangoJSONEncoder)
 
-        return super(JSONField, self).get_db_prep_save(value)
+        return super(JSONField, self).get_db_prep_save(value, connection)
 
 class UniqueSlugField(fields.SlugField):
   """


### PR DESCRIPTION
When you try to save a JSONField on newer djangos you would get:
- get_db_prep_save() takes exactly 3 arguments (2 given)

This fixes it by passing on the connection object (if specified) to
get_db_prep_save()
