### PR TITLE
import error in django > 1.6

### DIFF
--- a/django_common/admin.py
+++ b/django_common/admin.py
@@ -9,7 +9,10 @@ from django.contrib.admin.helpers import AdminForm
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils.translation import ugettext as _
-from django.utils.encoding import force_unicode
+try:
+    from django.utils.encoding import force_unicode
+except ImportError:
+    from django.utils.encoding import force_text  # django > 1.6
 from django.utils.html import escape
 from django.forms.formsets import all_valid
 from django.contrib.admin import helpers


### PR DESCRIPTION
force_unicode has changed to force_text
https://github.com/django/django/blob/stable/1.7.x/django/utils/encoding.py#L65