### PR TITLE
fix: Pass form fields with HiddenInput widget through render_form_field

### DIFF
--- a/django_common/templatetags/custom_tags.py
+++ b/django_common/templatetags/custom_tags.py
@@ -25,7 +25,9 @@ class FormFieldNode(template.Node):
 
         widget = form_field.field.widget
 
-        if isinstance(widget, widgets.RadioSelect):
+        if isinstance(widget, widgets.HiddenInput):
+            return form_field
+        elif isinstance(widget, widgets.RadioSelect):
             t = get_template('common/fragments/radio_field.html')
         elif isinstance(widget, widgets.CheckboxInput):
             t = get_template('common/fragments/checkbox_field.html')


### PR DESCRIPTION
Form fields with the HiddenInput() widget were being rendered using the form_field.html template, which includes a label and container markup. render_form_field should pass these form fields directly through instead of rendering them with a template.
I noticed this in django_base_project's signup form, which includes a hidden field called confirmation_key: https://github.com/pennersr/django-allauth/blob/master/allauth/account/forms.py#L286  