### PR TITLE
Add compatibility fixes Django v1.8 and v1.9

### DIFF
--- a/django_common/admin.py
+++ b/django_common/admin.py
@@ -3,7 +3,6 @@ from __future__ import print_function, unicode_literals, with_statement, divisio
 from django.db import models
 from django.views.decorators.csrf import csrf_protect
 from django.utils.decorators import method_decorator
-from django.contrib.admin.util import unquote, flatten_fieldsets
 from django.contrib.admin.options import BaseModelAdmin, ModelAdmin
 from django.contrib.admin.helpers import AdminForm
 from django.core.exceptions import PermissionDenied
@@ -17,7 +16,8 @@ from django.forms.models import (inlineformset_factory, BaseInlineFormSet)
 from django import forms
 from django.utils.functional import curry
 
-from django_common.compat import atomic_decorator, force_unicode
+from django_common.compat import (atomic_decorator, force_unicode,
+                                  unquote, flatten_fieldsets)
 
 
 csrf_protect_m = method_decorator(csrf_protect)

--- a/django_common/compat.py
+++ b/django_common/compat.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals, with_statement, division
 
 import sys
-
+from django import VERSION
 from django.db import transaction
 from django.utils import encoding
 
@@ -21,6 +21,11 @@ elif hasattr(encoding, 'force_text'):
 else:
     force_unicode = lambda x: x
 
+
+if VERSION[1] >= 8:
+    from django.contrib.admin.utils import unquote, flatten_fieldsets
+else:
+    from django.contrib.admin.util import unquote, flatten_fieldsets
 
 if not PY2:
     string_types = (str,)


### PR DESCRIPTION
Hi,

I added compatibility support for Django versions less than 1.8 to import

```py
from django.contrib.admin.util import unquote, flatten_fieldsets
```

And for Django versions greater than 1.8 

```py
from django.contrib.admin.utils import unquote, flatten_fieldsets
```